### PR TITLE
Fixed potential too many respawns bug of Pkunk

### DIFF
--- a/src/uqm/ships/pkunk/pkunk.c
+++ b/src/uqm/ships/pkunk/pkunk.c
@@ -422,7 +422,7 @@ pkunk_preprocess (ELEMENT *ElementPtr)
 		HELEMENT hPhoenix = 0;
         // TODO: Verify this
 		if ((signed)((TFB_Random () >> 10) % 100) < (INITIAL_RESPAWN_CHANCE - 1)
-				- (StarShipPtr->static_counter * RESPAWN_CHANCE_DECREMENT))
+				- ((signed)StarShipPtr->static_counter * RESPAWN_CHANCE_DECREMENT))
 			hPhoenix = AllocElement ();
 
 		if (hPhoenix)


### PR DESCRIPTION
AmonX reported a bug with too many Pkunk respawns on Windows. I suppose it's caused by
 http://stackoverflow.com/questions/5416414/signed-unsigned-comparisons

> When comparing signed with unsigned, the compiler converts the signed value to unsigned